### PR TITLE
Winpty cygwin support

### DIFF
--- a/native/cyglaunch/CMakeLists.txt
+++ b/native/cyglaunch/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.4)
+project(cyglaunch)
+
+set(SOURCE_FILES ../exec_pty.c ../exec_pty.h ../openpty.c ../pfind.c main.c)
+add_executable(cyglaunch ${SOURCE_FILES})

--- a/native/cyglaunch/main.c
+++ b/native/cyglaunch/main.c
@@ -1,0 +1,129 @@
+#include <sys/fcntl.h>
+#include <cygwin/stdlib.h>
+#include <sys/unistd.h>
+#include <w32api/minwindef.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <w32api/windef.h>
+#include <w32api/winbase.h>
+#include <sys/wait.h>
+#include "../exec_pty.h"
+#include <sys/cygwin.h>
+#include <locale.h>
+#include <w32api/stringapiset.h>
+
+struct pty_t {
+    int fdm;
+    char slave_name[100];
+};
+
+struct thread_data_t {
+    int fdm;
+    HANDLE pipe;
+};
+
+volatile bool shutting_down = false;
+
+int create_pty(struct pty_t *pty) {
+    pty->fdm = open("/dev/ptmx", O_RDWR|O_NOCTTY);
+    if (pty->fdm < 0)
+        return -1;
+    if (grantpt(pty->fdm) < 0) {
+        close(pty->fdm);
+        return -1;
+    }
+    if (unlockpt(pty->fdm) < 0) {
+        close(pty->fdm);
+        return -1;
+    }
+    char *slave_name = ptsname(pty->fdm);
+    if (slave_name == NULL) {
+        close(pty->fdm);
+        return -1;
+    }
+    strcpy(pty->slave_name, slave_name);
+    return 0;
+}
+
+
+void* writePipe(void *arg) {
+    struct thread_data_t thread_data = *(struct thread_data_t*)arg;
+    char buf[1024];
+    while(!shutting_down) {
+        ssize_t len = read(thread_data.fdm, buf, 1024);
+        if (len > 0) WriteFile(thread_data.pipe, buf, (DWORD)len, NULL, NULL);
+    }
+    return NULL;
+}
+
+void* readPipe(void *arg) {
+    struct thread_data_t thread_data = *(struct thread_data_t*)arg;
+    char buf[1024];
+    while(!shutting_down) {
+        DWORD len;
+        ReadFile(thread_data.pipe, buf, 1024, &len, NULL);
+        if (len > 0) {
+            write(thread_data.fdm, buf, len);
+        }
+    }
+    return NULL;
+}
+
+char* convert_path(char *command) {
+    int len = MultiByteToWideChar(CP_UTF8, 0, command, -1, NULL, 0);
+    wchar_t *wp = (wchar_t *) malloc (len * sizeof(wchar_t));
+    MultiByteToWideChar(CP_UTF8, 0, command, -1, wp, len);
+
+    char *buf = malloc(32768);
+    cygwin_conv_path(CCP_WIN_W_TO_POSIX | CCP_ABSOLUTE, wp, buf, 32768);
+    return buf;
+}
+
+int main(int argc, char* argv[], char* envp[]) {
+    struct pty_t pty;
+    struct pty_t err_pty;
+
+    if (create_pty(&pty) < 0) return -1;
+    if (create_pty(&err_pty) < 0) return -1;
+
+    int arg = 1;
+    struct thread_data_t thread_data_in = {pty.fdm, CreateFile(argv[arg++], GENERIC_READ, 0, NULL, OPEN_EXISTING, 0, NULL)};
+    struct thread_data_t thread_data_out = {pty.fdm, CreateFile(argv[arg++], GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL)};
+    struct thread_data_t thread_data_err = {err_pty.fdm, CreateFile(argv[arg++], GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL)};
+
+    char *command = argv[arg++];
+    int channels[3];
+
+    char *path = convert_path(command);
+
+    char * cargv[argc - arg + 2];
+    memcpy(cargv + 1, argv + arg, sizeof(char*) * (argc - arg));
+    cargv[0] = path;
+    cargv[argc - arg + 1] = NULL;
+
+    pid_t child_pid = exec_pty(path, cargv, envp, ".", channels, pty.slave_name, pty.fdm, err_pty.slave_name, err_pty.fdm, true);
+    free(path);
+
+    pthread_t tid[3];
+    pthread_create(&tid[0], NULL, &readPipe, &thread_data_in);
+    pthread_create(&tid[1], NULL, &writePipe, &thread_data_out);
+    pthread_create(&tid[2], NULL, &writePipe, &thread_data_err);
+
+    int status;
+    waitpid(child_pid, &status, 0);
+
+    shutting_down = true;
+
+    // Not shutting down the stdin thread because there is no way to abort synchronous ReadFile.
+    // Since the process is already dead, it doesn't matter anyway.
+
+    close(thread_data_out.fdm);
+    pthread_join(tid[1], NULL);
+    CloseHandle(thread_data_out.pipe);
+
+    close(thread_data_err.fdm);
+    pthread_join(tid[2], NULL);
+    CloseHandle(thread_data_err.pipe);
+
+    return WEXITSTATUS(status);
+}

--- a/src/com/pty4j/PtyProcess.java
+++ b/src/com/pty4j/PtyProcess.java
@@ -54,7 +54,7 @@ public abstract class PtyProcess extends Process {
 
   public static PtyProcess exec(String[] command, String[] environment, String workingDirectory, boolean console) throws IOException {
     if (Platform.isWindows()) {
-      return new WinPtyProcess(command, environment, workingDirectory);
+      return new WinPtyProcess(command, environment, workingDirectory, console);
     }
     return new UnixPtyProcess(command, environment, workingDirectory, new Pty(console), console ? new Pty() : null);
   }

--- a/src/com/pty4j/PtyProcess.java
+++ b/src/com/pty4j/PtyProcess.java
@@ -3,6 +3,7 @@ package com.pty4j;
 import com.pty4j.unix.Pty;
 import com.pty4j.unix.UnixPtyProcess;
 import com.pty4j.util.PtyUtil;
+import com.pty4j.windows.CygwinPtyProcess;
 import com.pty4j.windows.WinPtyProcess;
 import com.sun.jna.Platform;
 import com.sun.jna.platform.win32.Advapi32Util;
@@ -36,20 +37,24 @@ public abstract class PtyProcess extends Process {
 
   public abstract WinSize getWinSize() throws IOException;
 
-  public static PtyProcess exec(String[] command) throws IOException {
+  public static PtyProcess exec(String[] command) throws Exception {
     return exec(command, null);
   }
 
-  public static PtyProcess exec(String[] command, Map<String, String> environment) throws IOException {
-    return exec(command, environment, null, false);
+  public static PtyProcess exec(String[] command, Map<String, String> environment) throws Exception {
+    return exec(command, environment, null, false, false);
   }
 
-  public static PtyProcess exec(String[] command, Map<String, String> environment, String workingDirectory) throws IOException {
-    return exec(command, environment, workingDirectory, false);
+  public static PtyProcess exec(String[] command, Map<String, String> environment, String workingDirectory) throws Exception {
+    return exec(command, environment, workingDirectory, false, false);
   }
 
-  public static PtyProcess exec(String[] command, Map<String, String> environment, String workingDirectory, boolean console) throws IOException {
+  public static PtyProcess exec(String[] command, Map<String, String> environment, String workingDirectory, boolean console, boolean cygwin)
+    throws Exception {
     if (Platform.isWindows()) {
+      if (cygwin) {
+        return new CygwinPtyProcess(command, environment, workingDirectory);
+      }
       return new WinPtyProcess(command, Advapi32Util.getEnvironmentBlock(environment), workingDirectory, console);
     }
     return new UnixPtyProcess(command, PtyUtil.toStringArray(environment), workingDirectory, new Pty(console), console ? new Pty() : null);

--- a/src/com/pty4j/PtyProcess.java
+++ b/src/com/pty4j/PtyProcess.java
@@ -5,6 +5,7 @@ import com.pty4j.unix.UnixPtyProcess;
 import com.pty4j.util.PtyUtil;
 import com.pty4j.windows.WinPtyProcess;
 import com.sun.jna.Platform;
+import com.sun.jna.platform.win32.Advapi32Util;
 
 import java.io.IOException;
 import java.util.Map;
@@ -36,26 +37,21 @@ public abstract class PtyProcess extends Process {
   public abstract WinSize getWinSize() throws IOException;
 
   public static PtyProcess exec(String[] command) throws IOException {
-    return exec(command, (String[])null);
+    return exec(command, null);
   }
 
-  public static PtyProcess exec(String[] command, String[] environment) throws IOException {
+  public static PtyProcess exec(String[] command, Map<String, String> environment) throws IOException {
     return exec(command, environment, null, false);
   }
 
   public static PtyProcess exec(String[] command, Map<String, String> environment, String workingDirectory) throws IOException {
-    return exec(command, PtyUtil.toStringArray(environment), workingDirectory, false);
+    return exec(command, environment, workingDirectory, false);
   }
 
-  public static PtyProcess exec(String[] command, Map<String, String> environment, String workingDirectory, boolean console)
-    throws IOException {
-    return exec(command, PtyUtil.toStringArray(environment), workingDirectory, console);
-  }
-
-  public static PtyProcess exec(String[] command, String[] environment, String workingDirectory, boolean console) throws IOException {
+  public static PtyProcess exec(String[] command, Map<String, String> environment, String workingDirectory, boolean console) throws IOException {
     if (Platform.isWindows()) {
-      return new WinPtyProcess(command, environment, workingDirectory, console);
+      return new WinPtyProcess(command, Advapi32Util.getEnvironmentBlock(environment), workingDirectory, console);
     }
-    return new UnixPtyProcess(command, environment, workingDirectory, new Pty(console), console ? new Pty() : null);
+    return new UnixPtyProcess(command, PtyUtil.toStringArray(environment), workingDirectory, new Pty(console), console ? new Pty() : null);
   }
 }

--- a/src/com/pty4j/util/PtyUtil.java
+++ b/src/com/pty4j/util/PtyUtil.java
@@ -88,13 +88,21 @@ public class PtyUtil {
   }
 
   public static File resolveNativeLibrary(File parent) {
+    return resolveNativeFile(parent, getNativeLibraryName());
+  }
+
+  public static File resolveNativeFile(String fileName) throws Exception {
+    return resolveNativeFile(new File(getPtyLibFolderPath()), fileName);
+  }
+
+  public static File resolveNativeFile(File parent, String fileName) {
     File path = new File(parent, getPlatformFolder());
 
     path = isWinXp() ? new File(path, "xp") :
             (Platform.is64Bit() ? new File(path, "x86_64") :
                     new File(path, "x86"));
 
-    return new File(path, getNativeLibraryName());
+    return new File(path, fileName);
   }
 
   private static String getPlatformFolder() {

--- a/src/com/pty4j/windows/CygwinPtyProcess.java
+++ b/src/com/pty4j/windows/CygwinPtyProcess.java
@@ -1,0 +1,188 @@
+package com.pty4j.windows;
+
+import com.pty4j.PtyProcess;
+import com.pty4j.WinSize;
+import com.pty4j.util.PtyUtil;
+import com.sun.jna.platform.win32.WinBase;
+import com.sun.jna.platform.win32.WinError;
+import com.sun.jna.platform.win32.WinNT;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.pty4j.windows.WinPty.KERNEL32;
+
+public class CygwinPtyProcess extends PtyProcess {
+  private static final int CONNECT_PIPE_TIMEOUT = 1000;
+
+  private static final int PIPE_ACCESS_INBOUND = 1;
+  private static final int PIPE_ACCESS_OUTBOUND = 2;
+
+  private static final AtomicInteger processCounter = new AtomicInteger();
+
+  private final Process myProcess;
+  private final NamedPipe myInputPipe;
+  private final NamedPipe myOutputPipe;
+  private final NamedPipe myErrorPipe;
+  private final WinNT.HANDLE myInputHandle;
+  private final WinNT.HANDLE myOutputHandle;
+  private final WinNT.HANDLE myErrorHandle;
+
+  public CygwinPtyProcess(String[] command, Map<String, String> environment, String workingDirectory) throws Exception {
+    String pipePrefix = String.format("\\\\.\\pipe\\cygwinpty-%d-%d-", KERNEL32.GetCurrentProcessId(), processCounter.getAndIncrement());
+    String inPipeName = pipePrefix + "in";
+    String outPipeName = pipePrefix + "out";
+    String errPipeName = pipePrefix + "err";
+
+    myInputHandle = KERNEL32.CreateNamedPipeA(inPipeName, PIPE_ACCESS_OUTBOUND | WinNT.FILE_FLAG_OVERLAPPED, 0, 1, 0, 0, 0, null);
+    myOutputHandle = KERNEL32.CreateNamedPipeA(outPipeName, PIPE_ACCESS_INBOUND | WinNT.FILE_FLAG_OVERLAPPED, 0, 1, 0, 0, 0, null);
+    myErrorHandle = KERNEL32.CreateNamedPipeA(errPipeName, PIPE_ACCESS_INBOUND | WinNT.FILE_FLAG_OVERLAPPED, 0, 1, 0, 0, 0, null);
+
+    if (myInputHandle == WinBase.INVALID_HANDLE_VALUE ||
+        myOutputHandle == WinBase.INVALID_HANDLE_VALUE ||
+        myErrorHandle == WinBase.INVALID_HANDLE_VALUE) {
+      closeHandles();
+      throw new IOException("Unable to create a named pipe");
+    }
+
+    myInputPipe = new NamedPipe(myInputHandle);
+    myOutputPipe = new NamedPipe(myOutputHandle);
+    myErrorPipe = new NamedPipe(myErrorHandle);
+
+    myProcess = startProcess(inPipeName, outPipeName, errPipeName, workingDirectory, command, environment);
+  }
+
+  private Process startProcess(String inPipeName,
+                               String outPipeName,
+                               String errPipeName,
+                               String workingDirectory,
+                               String[] command,
+                               Map<String, String> environment) throws Exception {
+    ProcessBuilder processBuilder =
+      new ProcessBuilder(PtyUtil.resolveNativeFile("cyglaunch.exe").getAbsolutePath(), inPipeName, outPipeName, errPipeName);
+    for (String s : command) {
+      processBuilder.command().add(s);
+    }
+    processBuilder.directory(new File(workingDirectory));
+    processBuilder.environment().putAll(environment);
+    Process process = processBuilder.start();
+
+    try {
+      waitForPipe(myInputHandle);
+      waitForPipe(myOutputHandle);
+      waitForPipe(myErrorHandle);
+    } catch (IOException e) {
+      process.destroy();
+      closeHandles();
+      throw e;
+    }
+
+    new Thread() {
+      @Override
+      public void run() {
+        while (true) {
+          try {
+            myProcess.waitFor();
+            break;
+          }
+          catch (InterruptedException ignore) { }
+        }
+
+        closeHandles();
+      }
+    }.start();
+
+    return process;
+  }
+
+  private static void waitForPipe(WinNT.HANDLE handle) throws IOException {
+    WinNT.HANDLE connectEvent = KERNEL32.CreateEventA(null, true, false, null);
+
+    WinBase.OVERLAPPED povl = new WinBase.OVERLAPPED();
+    povl.hEvent = connectEvent;
+
+    boolean success = KERNEL32.ConnectNamedPipe(handle, povl);
+    if (!success) {
+      switch (KERNEL32.GetLastError()) {
+        case WinError.ERROR_PIPE_CONNECTED:
+          success = true;
+          break;
+        case WinError.ERROR_IO_PENDING:
+          if (KERNEL32.WaitForSingleObject(connectEvent, CONNECT_PIPE_TIMEOUT) != WinBase.WAIT_OBJECT_0) {
+            KERNEL32.CancelIo(handle);
+
+            success = false;
+          }
+          else {
+            success = true;
+          }
+
+          break;
+      }
+    }
+
+    KERNEL32.CloseHandle(connectEvent);
+
+    if (!success) throw new IOException("Cannot connect to a named pipe");
+  }
+
+  @Override
+  public boolean isRunning() {
+    try {
+      myProcess.exitValue();
+      return false;
+    } catch(IllegalThreadStateException e) {
+      return true;
+    }
+  }
+
+  @Override
+  public void setWinSize(WinSize winSize) {
+    throw new RuntimeException("Not implemented");
+  }
+
+  @Override
+  public WinSize getWinSize() throws IOException {
+    throw new RuntimeException("Not implemented");
+  }
+
+  @Override
+  public OutputStream getOutputStream() {
+    return new WinPTYOutputStream(myInputPipe);
+  }
+
+  @Override
+  public InputStream getInputStream() {
+    return new WinPTYInputStream(myOutputPipe);
+  }
+
+  @Override
+  public InputStream getErrorStream() {
+    return new WinPTYInputStream(myErrorPipe);
+  }
+
+  @Override
+  public int waitFor() throws InterruptedException {
+    return myProcess.waitFor();
+  }
+
+  @Override
+  public int exitValue() {
+    return myProcess.exitValue();
+  }
+
+  @Override
+  public void destroy() {
+    myProcess.destroy();
+  }
+
+  private void closeHandles() {
+    KERNEL32.CloseHandle(myInputHandle);
+    KERNEL32.CloseHandle(myOutputHandle);
+    KERNEL32.CloseHandle(myErrorHandle);
+  }
+}

--- a/src/com/pty4j/windows/WinPTYOutputStream.java
+++ b/src/com/pty4j/windows/WinPTYOutputStream.java
@@ -34,7 +34,7 @@ public class WinPTYOutputStream extends OutputStream {
       return;
     }
     byte[] tmpBuf = new byte[len];
-    System.arraycopy(b, off, tmpBuf, off, len);
+    System.arraycopy(b, off, tmpBuf, 0, len);
 
     myNamedPipe.write(tmpBuf, len);
   }

--- a/src/com/pty4j/windows/WinPTYOutputStream.java
+++ b/src/com/pty4j/windows/WinPTYOutputStream.java
@@ -11,16 +11,19 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class WinPTYOutputStream extends OutputStream {
+  private final NamedPipe myNamedPipe;
+  private boolean myClosed;
 
-  private final WinPty myWinPty;
-
-  public WinPTYOutputStream(WinPty winPty) {
-    myWinPty = winPty;
+  public WinPTYOutputStream(NamedPipe namedPipe) {
+    myNamedPipe = namedPipe;
   }
-
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
+    if (myClosed) {
+      return;
+    }
+
     if (b == null) {
       throw new NullPointerException();
     }
@@ -33,7 +36,7 @@ public class WinPTYOutputStream extends OutputStream {
     byte[] tmpBuf = new byte[len];
     System.arraycopy(b, off, tmpBuf, off, len);
 
-    myWinPty.write(tmpBuf, len);
+    myNamedPipe.write(tmpBuf, len);
   }
 
   @Override
@@ -45,7 +48,8 @@ public class WinPTYOutputStream extends OutputStream {
 
   @Override
   public void close() throws IOException {
-    myWinPty.close();
+    myClosed = true;
+    myNamedPipe.markClosed();
   }
 
   @Override

--- a/src/com/pty4j/windows/WinPty.java
+++ b/src/com/pty4j/windows/WinPty.java
@@ -24,11 +24,11 @@ public class WinPty {
   private boolean myClosed = false;
 
 
-  public WinPty(String cmdline, String cwd, String env) throws PtyException {
+  public WinPty(String cmdline, String cwd, String env, boolean consoleMode) throws PtyException {
     int cols = Integer.getInteger("win.pty.cols", 80);
     int rows = Integer.getInteger("win.pty.rows", 25);
     
-    myWinpty = INSTANCE.winpty_open(cols, rows);
+    myWinpty = INSTANCE.winpty_open(cols, rows, consoleMode);
 
     if (myWinpty == null) {
       throw new PtyException("winpty is null");
@@ -140,7 +140,7 @@ public class WinPty {
      *
      * This function creates a new agent process and connects to it.
      */
-    winpty_t winpty_open(int cols, int rows);
+    winpty_t winpty_open(int cols, int rows, boolean consoleMode);
 
     /*
      * Start a child process.  Either (but not both) of appname and cmdline may

--- a/src/com/pty4j/windows/WinPty.java
+++ b/src/com/pty4j/windows/WinPty.java
@@ -113,6 +113,29 @@ public class WinPty {
                           IntByReference lpBytesLeftThisMessage);
 
     boolean ReadFile(WinNT.HANDLE handle, Buffer buffer, int i, IntByReference reference, WinBase.OVERLAPPED overlapped);
+
+    WinNT.HANDLE CreateNamedPipeA(String lpName,
+                                  int dwOpenMode,
+                                  int dwPipeMode,
+                                  int nMaxInstances,
+                                  int nOutBufferSize,
+                                  int nInBufferSize,
+                                  int nDefaultTimeout,
+                                  WinBase.SECURITY_ATTRIBUTES securityAttributes);
+
+    boolean ConnectNamedPipe(WinNT.HANDLE hNamedPipe, WinBase.OVERLAPPED overlapped);
+
+    boolean CloseHandle(WinNT.HANDLE hObject);
+
+    WinNT.HANDLE CreateEventA(WinBase.SECURITY_ATTRIBUTES lpEventAttributes, boolean bManualReset, boolean bInitialState, String lpName);
+
+    int GetLastError();
+
+    int WaitForSingleObject(WinNT.HANDLE hHandle, int dwMilliseconds);
+
+    boolean CancelIo(WinNT.HANDLE hFile);
+
+    int GetCurrentProcessId();
   }
 
   public static WinPtyLib INSTANCE = (WinPtyLib)Native.loadLibrary(getLibraryPath(), WinPtyLib.class);

--- a/src/com/pty4j/windows/WinPty.java
+++ b/src/com/pty4j/windows/WinPty.java
@@ -20,6 +20,7 @@ public class WinPty {
   private final winpty_t myWinpty;
 
   private NamedPipe myNamedPipe;
+  private NamedPipe myErrNamedPipe;
   private boolean myClosed = false;
 
 
@@ -41,9 +42,11 @@ public class WinPty {
 
     if ((c = INSTANCE.winpty_start_process(myWinpty, null, cmdlineArray, cwdArray, envArray)) != 0) {
       throw new PtyException("Error running process:" + c);
+
     }
 
     myNamedPipe = new NamedPipe(myWinpty.dataPipe);
+    if (consoleMode) myErrNamedPipe = new NamedPipe(myWinpty.errDataPipe);
   }
 
   private static char[] toCharArray(String string) {
@@ -68,6 +71,7 @@ public class WinPty {
     INSTANCE.winpty_close(myWinpty);
 
     myNamedPipe.markClosed();
+    if (myErrNamedPipe != null) myErrNamedPipe.markClosed();
 
     myClosed = true;
   }
@@ -87,9 +91,14 @@ public class WinPty {
     return myNamedPipe;
   }
 
+  public NamedPipe getErrorPipe() {
+    return myErrNamedPipe;
+  }
+
   public static class winpty_t extends Structure {
     public WinNT.HANDLE controlPipe;
     public WinNT.HANDLE dataPipe;
+    public WinNT.HANDLE errDataPipe;
     public boolean open;
   }
 

--- a/src/com/pty4j/windows/WinPty.java
+++ b/src/com/pty4j/windows/WinPty.java
@@ -10,8 +10,7 @@ import com.sun.jna.platform.win32.WinBase;
 import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.ptr.IntByReference;
 import jtermios.windows.WinAPI;
-import java.io.File;
-import java.io.IOException;
+
 import java.nio.Buffer;
 
 /**
@@ -80,24 +79,12 @@ public class WinPty {
     return INSTANCE.winpty_get_exit_code(myWinpty);
   }
 
-  public int read(byte[] buf, int len) throws IOException {
-    if (myClosed) {
-      return 0;
-    }
-
-    return myNamedPipe.read(buf, len);
+  public NamedPipe getInputPipe() {
+    return myNamedPipe;
   }
 
-  public int available() throws IOException {
-    return myNamedPipe.available();
-  }
-
-  public void write(byte[] buf, int len) throws IOException {
-    if (myClosed) {
-      return;
-    }
-
-    myNamedPipe.write(buf, len);
+  public NamedPipe getOutputPipe() {
+    return myNamedPipe;
   }
 
   public static class winpty_t extends Structure {

--- a/src/com/pty4j/windows/WinPtyProcess.java
+++ b/src/com/pty4j/windows/WinPtyProcess.java
@@ -24,8 +24,8 @@ public class WinPtyProcess extends PtyProcess {
     catch (PtyException e) {
       throw new IOException("Couldn't create PTY", e);
     }
-    myInputStream = new WinPTYInputStream(myWinPty);
-    myOutputStream = new WinPTYOutputStream(myWinPty);
+    myInputStream = new WinPTYInputStream(myWinPty.getInputPipe());
+    myOutputStream = new WinPTYOutputStream(myWinPty.getOutputPipe());
   }
 
   @Override

--- a/src/com/pty4j/windows/WinPtyProcess.java
+++ b/src/com/pty4j/windows/WinPtyProcess.java
@@ -17,9 +17,9 @@ public class WinPtyProcess extends PtyProcess {
   private final WinPTYInputStream myInputStream;
   private final WinPTYOutputStream myOutputStream;
 
-  public WinPtyProcess(String[] command, String[] environment, String workingDirectory, boolean consoleMode) throws IOException {
+  public WinPtyProcess(String[] command, String environment, String workingDirectory, boolean consoleMode) throws IOException {
     try {
-      myWinPty = new WinPty(Joiner.on(" ").join(command), workingDirectory, null, consoleMode); //TODO: use environment
+      myWinPty = new WinPty(Joiner.on(" ").join(command), workingDirectory, environment, consoleMode);
     }
     catch (PtyException e) {
       throw new IOException("Couldn't create PTY", e);

--- a/src/com/pty4j/windows/WinPtyProcess.java
+++ b/src/com/pty4j/windows/WinPtyProcess.java
@@ -17,9 +17,9 @@ public class WinPtyProcess extends PtyProcess {
   private final WinPTYInputStream myInputStream;
   private final WinPTYOutputStream myOutputStream;
 
-  public WinPtyProcess(String[] command, String[] environment, String workingDirectory) throws IOException {
+  public WinPtyProcess(String[] command, String[] environment, String workingDirectory, boolean consoleMode) throws IOException {
     try {
-      myWinPty = new WinPty(Joiner.on(" ").join(command), workingDirectory, null); //TODO: use environment
+      myWinPty = new WinPty(Joiner.on(" ").join(command), workingDirectory, null, consoleMode); //TODO: use environment
     }
     catch (PtyException e) {
       throw new IOException("Couldn't create PTY", e);


### PR DESCRIPTION
This pull request includes all commits from traff/pty4j#12 branch, plus additional commit to support cygwin binaries.

The problem with cygwin is that simple stderr redirection via SetStdHandle does not work: it has its own logic which tries to determine a type of the stderr handle, and something goes wrong there if we try to redirect to a dedicated screen buffer.

This implementation uses more or less the same approach as used for unix systems: creates two ptys in cygwin environment and transfers data between those ptys and named pipes.