### PR TITLE
Fix race conditions in NamedPipe and clean it up.

### DIFF
--- a/src/com/pty4j/windows/WinPTYInputStream.java
+++ b/src/com/pty4j/windows/WinPTYInputStream.java
@@ -38,26 +38,7 @@ public class WinPTYInputStream extends InputStream {
     if (myClosed) {
       return 0;
     }
-
-    if (buf == null) {
-      throw new NullPointerException();
-    }
-    if ((off < 0) || (off > buf.length) || (len < 0) || ((off + len) > buf.length) || ((off + len) < 0)) {
-      throw new IndexOutOfBoundsException();
-    }
-    if (len == 0) {
-      return 0;
-    }
-    byte[] tmpBuf = new byte[len];
-
-    len = myNamedPipe.read(tmpBuf, len);
-
-    if (len <= 0) {
-      return -1;
-    }
-    System.arraycopy(tmpBuf, 0, buf, off, len);
-
-    return len;
+    return myNamedPipe.read(buf, off, len);
   }
 
   @Override

--- a/src/com/pty4j/windows/WinPTYOutputStream.java
+++ b/src/com/pty4j/windows/WinPTYOutputStream.java
@@ -42,27 +42,21 @@ public class WinPTYOutputStream extends OutputStream {
       return;
     }
 
-    byte[] tmpBuf;
     if (myPatchNewline) {
-      tmpBuf = new byte[len * 2];
-      int newLen = len;
-      int ind_b = off;
-      int ind_tmp = 0;
-      while (ind_b < off + len) {
-        if (b[ind_b] == '\n') {
-          tmpBuf[ind_tmp++] = '\r';
-          newLen++;
+      byte[] newBuf = new byte[len * 2];
+      int newPos = 0;
+      for (int i = off; i < off + len; ++i) {
+        if (b[i] == '\n') {
+          newBuf[newPos++] = '\r';
         }
-        tmpBuf[ind_tmp++] = b[ind_b++];
+        newBuf[newPos++] = b[i];
       }
-      len = newLen;
-    }
-    else {
-      tmpBuf = new byte[len];
-      System.arraycopy(b, off, tmpBuf, 0, len);
+      b = newBuf;
+      off = 0;
+      len = newPos;
     }
 
-    myNamedPipe.write(tmpBuf, len);
+    myNamedPipe.write(b, off, len);
   }
 
   @Override

--- a/src/com/pty4j/windows/WinPty.java
+++ b/src/com/pty4j/windows/WinPty.java
@@ -5,6 +5,7 @@ import com.pty4j.WinSize;
 import com.pty4j.util.PtyUtil;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.platform.win32.WinBase;
 import com.sun.jna.platform.win32.WinNT;
@@ -116,13 +117,17 @@ public class WinPty {
 
   interface Kern32 extends Library {
     boolean PeekNamedPipe(WinNT.HANDLE hFile,
-                          Buffer lpBuffer,
+                          Pointer lpBuffer,
                           int nBufferSize,
                           IntByReference lpBytesRead,
                           IntByReference lpTotalBytesAvail,
                           IntByReference lpBytesLeftThisMessage);
 
-    boolean ReadFile(WinNT.HANDLE handle, Buffer buffer, int i, IntByReference reference, WinBase.OVERLAPPED overlapped);
+    boolean ReadFile(WinNT.HANDLE file, Pointer buf, int len, IntByReference actual, Pointer over);
+
+    boolean WriteFile(WinNT.HANDLE file, Pointer buf, int len, IntByReference actual, Pointer over);
+
+    boolean GetOverlappedResult(WinNT.HANDLE file, Pointer over, IntByReference actual, boolean wait);
 
     WinNT.HANDLE CreateNamedPipeA(String lpName,
                                   int dwOpenMode,


### PR DESCRIPTION
The named pipe is marked FILE_FLAG_OVERLAPPED, but we're doing I/O without
an OVERLAPPED structure.  MSDN states that this isn't allowed.  This blog
post[1] explains that it works, but only if the application is careful
never to issue two I/O operations at the same time.  The NamedPipe class
tries to achieve mutual exclusions using non-volatile boolean flags and
polling for available data.  In principle, this doesn't work, because AFAIK
Java has weak guarantees about non-volatile variables, and because the
threads could be interrupted immediately prior to the assignments to
readNotify and writeNotify.

With the current code, I can hang NamedPipe easily.  To reproduce, I
run IntelliJ or jediterm in a Windows VM, run "dir /s c:\", then mash the
keyboard for 5-60 seconds.  Eventually, the directory listing halts, and
nothing I do can unfreeze it.  I can observe that keypresses are still
getting through to the winpty-agent (using WINPTYDBG=1 and
winpty-debugserver).  From my debugging, it looks like the Java VM gets
stuck in this loop:

    while (writeNotify) {
    }//wait for write to finish

Nonetheless, I can see that writeNotify is being set to false.  writeNotify
isn't volatile, so I think Java is allowed to factor out the read, turning
the code into this:

    if (writeNotify) {
        while (true) {}
    }

[1] https://blogs.msdn.microsoft.com/oldnewthing/20121012-00/?p=6343

I've rewritten the NamedPipe class to instead have a read event, a write
event, and a shutdown event.  I/O blocking is implemented using
WaitForMultipleObjects() on the I/O event and the shutdown event.  A
concurrent read (or write) waits for existing reads (or writes) to complete
before beginning, but a read and a write may run concurrently.  When the
pipe is closed (or marked closed), the closeImpl() function sets the
shutdown event.  If any I/O operations are pending (a read is likely), then
the thread waiting on the I/O operation calls CancelIo().  Once all I/O
threads have finished, the close() function releases resources.

Aside from fixing the read-write race condition, it also stops available()
from calling PeekNamedPipe() with an invalid HANDLE value (which could have
been reopened in the meantime, in principle).

While writing this code, I noticed an interesting problem with the
ReadFile() and GetOverlappedResult() functions, which were declared to take
a WinBase.OVERLAPPED parameter.  A pending read operation would complete
successfully, but the amount of data read was invalid.  I fixed the problem
by changing the two functions to instead accept a Pointer parameter.  I
think the problem is that a parameter declared as WinBase.OVERLAPPED is
passed *by value*, but we need to pass it by reference, because Windows is
going to modify the structure asynchronously.  Passing WinBase.OVERLAPPED
*almost* works because the calling convention converts it to a pointer.
The address can change between calls, though.

I've tried to preserve the existing error handling behavior, roughly.
Details:

 * read(): Previously, read0() didn't throw IOException, because
   WinPty.KERNEL32.ReadFile() doesn't, and if ReadFile() failed, then
   read0() returned the amount of data transferred (presumably 0).  When
   the pipe was closed during a read() call, read() either returned 0
   (myHandle == null) or returned -1 (available() calls PeekNamedPipe()
   with an invalid HANDLE, throws an exception, read() catches it).  If
   Thread.sleep() were interrupted somehow, then read() returned -1.

   The only caller to read() (in WinPTYInputStream) considered all return
   values <= 0 to mean EOF and returned -1.  Therefore, I've made
   NamedPiped.read() simply return -1 on any kind of error or EOF
   condition.

 * write(): Previously, write() always returned wSuccess, which was always
   false.  write0() didn't throw an IOException, because
   Kernel32.INSTANCE.WriteFile() doesn't.  The only caller to write() (in
   WinPTYOutputStream) ignores the return value.  I changed
   NamedPipe.write() to return void.

 * close() threw an IOException if the pipe handle cannot be closed.  I
   preserved this throw.

Fixes https://github.com/traff/pty4j/issues/25