### PR TITLE
deprecate PTY_LIB_FOLDER environment variable (Fixes #17)

### DIFF
--- a/src/com/pty4j/util/PtyUtil.java
+++ b/src/com/pty4j/util/PtyUtil.java
@@ -1,6 +1,7 @@
 package com.pty4j.util;
 
 import com.google.common.base.Function;
+import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.pty4j.windows.WinPty;
 import com.sun.jna.Platform;
@@ -71,7 +72,12 @@ public class PtyUtil {
 
   @Nullable
   private static File getPreferredLibPtyFolder() {
-    String path = PTY_LIB_FOLDER != null ? PTY_LIB_FOLDER : System.getProperty(PREFERRED_NATIVE_FOLDER_KEY);
+    if (PTY_LIB_FOLDER != null) {
+      System.err.println("WARN: PTY_LIB_FOLDER environment variable is deprecated and" +
+          " will not be used in future releases." +
+          " Please set Java system property \"" + PREFERRED_NATIVE_FOLDER_KEY + "\" instead.");
+    }
+    String path = Objects.firstNonNull(PTY_LIB_FOLDER, System.getProperty(PREFERRED_NATIVE_FOLDER_KEY));
     if (path != null) {
       File dir = new File(path);
       if (dir.isAbsolute() && dir.isDirectory()) {


### PR DESCRIPTION
PTY_LIB_FOLDER is deprecated in favor of "pty4j.preferred.native.folder" system property, which is possible to configure programmatically:
System.setProperty("pty4j.preferred.native.folder", "/absolute/path/to/libpty")