### PR TITLE
fix NPE as Objects.firstNonNull expects not-null second parameter

### DIFF
--- a/src/com/pty4j/util/PtyUtil.java
+++ b/src/com/pty4j/util/PtyUtil.java
@@ -1,7 +1,6 @@
 package com.pty4j.util;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 import com.pty4j.windows.WinPty;
 import com.sun.jna.Platform;
@@ -77,7 +76,7 @@ public class PtyUtil {
           " will not be used in future releases." +
           " Please set Java system property \"" + PREFERRED_NATIVE_FOLDER_KEY + "\" instead.");
     }
-    String path = Objects.firstNonNull(PTY_LIB_FOLDER, System.getProperty(PREFERRED_NATIVE_FOLDER_KEY));
+    String path = PTY_LIB_FOLDER != null ? PTY_LIB_FOLDER : System.getProperty(PREFERRED_NATIVE_FOLDER_KEY);
     if (path != null) {
       File dir = new File(path);
       if (dir.isAbsolute() && dir.isDirectory()) {

--- a/test/com/pty4j/TestUtil.java
+++ b/test/com/pty4j/TestUtil.java
@@ -98,7 +98,10 @@ public class TestUtil {
   }
 
   public static void setLocalPtyLib() {
-    if (System.getProperty(PtyUtil.PREFERRED_NATIVE_FOLDER_KEY) == null) {
+    if ("false".equals(System.getProperty(PtyUtil.PREFERRED_NATIVE_FOLDER_KEY))) {
+      System.clearProperty(PtyUtil.PREFERRED_NATIVE_FOLDER_KEY);
+    }
+    else {
       System.setProperty(PtyUtil.PREFERRED_NATIVE_FOLDER_KEY, getBuiltNativeFolder().toString());
     }
   }


### PR DESCRIPTION
Fixed regression introduced by https://github.com/traff/pty4j/commit/ad4723fb886383a91c9fb1c5fca97b9a6c99fb01
Now tests cover such a regression: 'testJar' gradle task does the job.